### PR TITLE
Make PyInstaller bundle all necessary binaries for the mip library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To make a single file executable, we use [PyInstaller](https://pyinstaller.readt
 The command is:
 
 ```
-python -m eel script.py web --onefile --noconsole
+python -m eel script.py web --additional-hooks-dir=. --onefile --noconsole
 ```
 
 **Platform** means Windows, Mac OS X or Linux.  So if you run the above command on Linux, you can give the file to someone else running Linux.  So if the person who wants the app is running Windows, you need to run the above command on Windows.

--- a/hook-mip.py
+++ b/hook-mip.py
@@ -1,0 +1,15 @@
+# Ensures that PyInstaller copies the CBC binaries for the mip library.
+# See https://github.com/coin-or/python-mip/issues/76.
+# Should become obsolete once https://github.com/pyinstaller/pyinstaller/pull/4762
+# gets merged and makes it into the pyinstaller release.
+
+import os
+from PyInstaller.utils.hooks import get_package_paths
+
+datas = []
+_, mip_path = get_package_paths("mip")
+lib_path = os.path.join(mip_path, "libraries")
+
+for f in os.listdir(lib_path):
+    if f.endswith(".so") or f.endswith(".dll") or f.endswith(".dylib"):
+        datas.append((os.path.join(lib_path, f), "mip/libraries"))


### PR DESCRIPTION
Currently, when building (at least on Mac, probably on other platforms as well), compilation seems to go well. The binary will open a window, but when the algorithm is run, the program will crash (without any message in the GUI). The problem is that PyInstaller does not find certain dynamic libraries used by the mip library, which makes the program crash. This pull request adds a file `hook-mip.py` that tells PyInstaller about these files.

Note that the release command has an additional parameter, as detailed in the updated README.

Addresses https://github.com/coin-or/python-mip/issues/76, and will become obsolete when https://github.com/pyinstaller/pyinstaller/pull/4762 makes it into the pyinstaller release.