### PR TITLE
Give feedback for infeasible quotas.

### DIFF
--- a/test_stratification.py
+++ b/test_stratification.py
@@ -335,7 +335,7 @@ class FindDistributionMaximinTests(FindDistributionTests):
         fair_to_households = False
 
         # There are no feasible committees at all.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InfeasibleQuotasError):
             find_distribution_maximin(categories, people, columns_data, number_people_wanted, check_same_address,
                                       check_same_address_columns, fair_to_households)
 
@@ -399,7 +399,7 @@ class FindDistributionNashTests(FindDistributionTests):
         fair_to_households = False
 
         # There are no feasible committees at all.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InfeasibleQuotasError):
             find_distribution_nash(categories, people, columns_data, number_people_wanted, check_same_address,
                                    check_same_address_columns, fair_to_households)
 


### PR DESCRIPTION
When the quotas cannot be satisfied by any panel, suggest a way to relax the quotas such that the quotas become feasible. 

In more detail, the program suggests a “minimal” relaxation that is feasible, where “minimal” refers to the factors by which 
the quotas have to be multiplied. As a result, changes to previously-large quotas are preferred to changes to previously-small quotas.

> For instance, simultaneously increasing one upper quota from 5 to 7 (a factor of 1.4) and decreasing a lower quota from 4 to 3 (a factor of 0.75) is considered to be a relaxation by (0.4 + 0.25 = 0.65). This change is considered worse than increasing a single upper quota from 10 to 16 (a factor of 1.6, so a badness of 0.6) and is considered better than decreasing a single lower quota from 1 to 0 (a factor of 0, so a badness of 1). Among these three options for making a given set of quotas feasible, the algorithm would suggest the increase from 10 to 16.
